### PR TITLE
fix exception when using appsettings credentials

### DIFF
--- a/Components/Pages/Components/Modals/Bolt11QrModal.razor
+++ b/Components/Pages/Components/Modals/Bolt11QrModal.razor
@@ -5,6 +5,7 @@
 @inject IWebSocketService WebSocketService
 @inject IModalService ModalService
 @inject NavigationManager NavigationManager
+@inject IConfigurationService ConfigurationService
 
 <ModalWrapper>
     <ModalHeader>
@@ -40,8 +41,8 @@
 
     protected override async Task OnInitializedAsync()
     {
-        var baseUrl = await JSRuntime.InvokeAsync<string>("localStorage.getItem", "baseUrl");
-        var authToken = await JSRuntime.InvokeAsync<string>("localStorage.getItem", "password");
+        var baseUrl = await ConfigurationService.GetBaseUrlAsync();
+        var authToken = await ConfigurationService.GetPasswordAsync();
 
         if (string.IsNullOrEmpty(baseUrl) || string.IsNullOrEmpty(authToken))
         {

--- a/Components/Pages/Components/Modals/Bolt12QrModal.razor
+++ b/Components/Pages/Components/Modals/Bolt12QrModal.razor
@@ -5,6 +5,7 @@
 @inject IWebSocketService WebSocketService
 @inject IModalService ModalService
 @inject NavigationManager NavigationManager
+@inject IConfigurationService ConfigurationService
 
 <ModalWrapper>
     <ModalHeader>
@@ -35,8 +36,8 @@
 
     protected override async Task OnInitializedAsync()
     {
-        var baseUrl = await JSRuntime.InvokeAsync<string>("localStorage.getItem", "baseUrl");
-        var authToken = await JSRuntime.InvokeAsync<string>("localStorage.getItem", "password");
+        var baseUrl = await ConfigurationService.GetBaseUrlAsync();
+        var authToken = await ConfigurationService.GetPasswordAsync();
 
         if (string.IsNullOrEmpty(baseUrl) || string.IsNullOrEmpty(authToken))
         {


### PR DESCRIPTION
The Close button of BOLT-11/12 QRs doesn't work if credentials are stored in appsettings.

Injecting and using the new ConfigurationService instead of the JSRuntime seems to fix the problem.